### PR TITLE
adding full chain to imapd.pem instead of chain.pem

### DIFF
--- a/usr/local/bin/letsimap
+++ b/usr/local/bin/letsimap
@@ -21,7 +21,7 @@ then
     exit 1
 fi
 
-certFile=$certDir/cert.pem
+certFile=$certDir/fullchain.pem
 keyFile=$certDir/privkey.pem
 mergedFile=$certDir/imapd.pem
 


### PR DESCRIPTION
this will fix the issue with certificate verification as fullchain.pem also includes the intermediate certs.